### PR TITLE
Remove possible debug print

### DIFF
--- a/pylic/cli/commands/list.py
+++ b/pylic/cli/commands/list.py
@@ -18,7 +18,6 @@ class ListCommand(Command):
         unsorted = {
             installed["package"]: {"version": installed["version"], "license": installed["license"]} for installed in installed_licenses
         }
-        print("console_writer", console_writer)
         for package, rest in sorted(unsorted.items(), key=lambda k: k[0].lower()):  # type:ignore
             console_writer.line(f"{BLUE}{package}{END_STYLE} {LABEL}({rest['version']}){END_STYLE}: {rest['license']}")
         return 0


### PR DESCRIPTION
I believe this is a debug print from a previous commit? Regardless, it doesn't seem to be helpful output. For example:

```
± pylic list
console_writer <pylic.cli.console_writer.ConsoleWriter object at 0x10b2c04f0>
ach (0.2): MIT License
add-trailing-comma (2.1.0): MIT License
aiodns (3.0.0): MIT License
aiofiles (0.7.0): Other/Proprietary License
[...]
```